### PR TITLE
Fix units error on call to ggbio::ggsave

### DIFF
--- a/R/starfish_plot.r
+++ b/R/starfish_plot.r
@@ -342,7 +342,7 @@ for (j in 1:length(cluster_list)){
 
 
     pdfname=paste0(unique(chrss_j$code4),cluster_list[j],"_chrss.pdf")
-    ggbio::ggsave(pdfname,plot=p3,width=3,height=3,device = cairo_pdf)
+    ggbio::ggsave(pdfname,plot=p3,width=3,height=3,units="in",device = cairo_pdf)
 
   }
 }


### PR DESCRIPTION
Hi,

I was testing the package, really like it so far! I was getting an error on starfish_plot: 

>\> starfish_plot(sv.df, cnv.df, link_out$starfish_call, genome_v = "hg38")
Error in match.arg(units) : 'arg' must be of length 1

Explicitly adding a units argument when calling ggbio::ggsave() on starfish_plot.r fixes it. 